### PR TITLE
run_apacheds.sh: fix ldapmodify calls

### DIFF
--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -66,7 +66,7 @@ EOF
 echo "Deleting example partition"
 ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -64,7 +64,7 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
 ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword


### PR DESCRIPTION
run_apacheds.sh:
- replace 'ldapmodify -h' with 'ldapmodify -H', as current ldapmodify no longer recognizes -h as an option
- ldapmodify no longer has a '-p' option for the port, it now goes into the '-H' URI
- ldapdelete also uses '-H' now
- use proper LDAP URIs (`ldap://127.0.0.1:10389`)

https://manpages.ubuntu.com/manpages/jammy/en/man1/ldapmodify.1.html