### PR TITLE
Only enable TLS if the file `/etc/apacheds/apacheds.jks` exists.

### DIFF
--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -49,9 +49,11 @@ timeout 30 sh -c "while ! nc -z localhost 10389; do sleep 1; done"
 
 echo "ApacheDS Started"
 
-echo "Starting TLS"
+if [[ -f /etc/apacheds/apacheds.jks ]]
+then
+    echo "Starting TLS"
 
-ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -62,6 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 -
 
 EOF
+else
+    echo "/etc/apacheds/apacheds.jks does not exist, not starting TLS"
+fi
 
 echo "Deleting example partition"
 ldapdelete -r  -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -66,7 +66,7 @@ EOF
 echo "Deleting example partition"
 ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -64,7 +64,7 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
 ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword


### PR DESCRIPTION
based on #11 and also contains those fixes.

Only enable TLS if the file `/etc/apacheds/apacheds.jks` exists.