### PR TITLE
ShellCheck fixes

### DIFF
--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -130,12 +130,12 @@ export RDN=${DN_COMP/=/: }
 RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
 export RDN_VAL
 
-CTX_ENTRY=`base64 -w 0 <<EOF
+CTX_ENTRY=$(base64 -w 0 <<EOF
 dn: $DN
 objectClass: $OBJECT_CLASS
 $RDN
-EOF`
-
+EOF
+)
 export CTX_ENTRY
 
 ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -49,9 +49,11 @@ timeout 30 sh -c "while ! nc -z localhost 10389; do sleep 1; done"
 
 echo "ApacheDS Started"
 
-echo "Starting TLS"
+if [[ -f /etc/apacheds/apacheds.jks ]]
+then
+    echo "Starting TLS"
 
-ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -62,6 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 -
 
 EOF
+else
+    echo "/etc/apacheds/apacheds.jks does not exist, not starting TLS"
+fi
 
 echo "Deleting example partition"
 ldapdelete -r  -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -121,9 +121,9 @@ then
   /tmp/prerun.sh
 fi
 
-export DN_COMP=`echo $DN | sed 's/,.*//'`
+export DN_COMP=`echo "${DN}" | sed 's/,.*//'`
 export RDN=${DN_COMP/=/: }
-export RDN_VAL=`echo $DN_COMP | sed 's/.*=//'`
+export RDN_VAL=`echo "${DN_COMP}" | sed 's/.*=//'`
 
 export CTX_ENTRY=`base64 -w 0 <<EOF
 dn: $DN
@@ -298,7 +298,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -f "${LDIF_FILE}" -a -c
 fi
 
 
@@ -317,6 +317,6 @@ EOF
 
 
 jnum=$(jobs -l | grep " $! " | sed 's/\[\(.*\)\].*/\1/')
-echo "Backgroung job number: $jnum"
+echo "Backgroung job number: ${jnum}"
 
-fg $jnum
+fg "${jnum}"

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -121,9 +121,9 @@ then
   /tmp/prerun.sh
 fi
 
-export DN_COMP=`echo "${DN}" | sed 's/,.*//'`
+export DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
 export RDN=${DN_COMP/=/: }
-export RDN_VAL=`echo "${DN_COMP}" | sed 's/.*=//'`
+export RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
 
 export CTX_ENTRY=`base64 -w 0 <<EOF
 dn: $DN

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -122,6 +122,7 @@ then
   /tmp/prerun.sh
 fi
 
+# shellcheck disable=SC2001
 DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
 export DN_COMP
 export RDN=${DN_COMP/=/: }

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -66,7 +66,7 @@ EOF
 echo "Deleting example partition"
 ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -64,7 +64,7 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
 ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -122,7 +122,8 @@ then
   /tmp/prerun.sh
 fi
 
-export DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
+DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
+export DN_COMP
 export RDN=${DN_COMP/=/: }
 export RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
 

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -126,6 +126,7 @@ fi
 DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
 export DN_COMP
 export RDN=${DN_COMP/=/: }
+# shellcheck disable=SC2001
 RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
 export RDN_VAL
 

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -130,12 +130,13 @@ export RDN=${DN_COMP/=/: }
 RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
 export RDN_VAL
 
-export CTX_ENTRY=`base64 -w 0 <<EOF
+CTX_ENTRY=`base64 -w 0 <<EOF
 dn: $DN
 objectClass: $OBJECT_CLASS
 $RDN
 EOF`
 
+export CTX_ENTRY
 
 ldapmodify -H ldap://127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -51,7 +51,7 @@ echo "ApacheDS Started"
 
 echo "Starting TLS"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: ads-serverId=ldapServer,ou=servers,ads-directoryServiceId=default,ou=config
 changeType: modify
 replace: ads-keystoreFile
@@ -64,9 +64,9 @@ ads-certificatePassword: $APACHEDS_TLS_KS_PWD
 EOF
 
 echo "Deleting example partition"
-ldapdelete -r  -h 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
+ldapdelete -r  -h 127.0.0.1:10389 -D uid=admin,ou=system -w secret ads-partitionId=example,ou=partitions,ads-directoryServiceId=default,ou=config
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 version: 1
 
 dn: cn=schema
@@ -127,7 +127,7 @@ $RDN
 EOF`
 
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -a <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -a <<EOF
 dn: ads-partitionId=$RDN_VAL,ou=partitions,ads-directoryServiceId=default,ou=config
 objectclass: top
 objectClass: ads-base
@@ -293,7 +293,7 @@ echo "ApacheDS Restarted"
 if [[ -z "${LDIF_FILE}" ]]; then
     echo "No initial LDIF file provided"
 else
-    ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
+    ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret -f $LDIF_FILE -a -c
 fi
 
 
@@ -302,7 +302,7 @@ fi
 
 echo "Setting admin password"
 
-ldapmodify -H 127.0.0.1 -p 10389 -D uid=admin,ou=system -w secret <<EOF
+ldapmodify -H 127.0.0.1:10389 -D uid=admin,ou=system -w secret <<EOF
 dn: uid=admin,ou=system
 changeType: modify
 replace: userPassword

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -38,6 +38,7 @@ set -m
 
 CLASSPATH=$(JARS=("$ADS_HOME"/lib/*.jar); IFS=:; echo "${JARS[*]}")
 
+# shellcheck disable=SC2153
 ADS_INSTANCE="$ADS_INSTANCES/$ADS_INSTANCE_NAME"
 
 ADS_OUT="$ADS_INSTANCE/log/apacheds.out"

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -41,9 +41,6 @@ CLASSPATH=$(JARS=("$ADS_HOME"/lib/*.jar); IFS=:; echo "${JARS[*]}")
 # shellcheck disable=SC2153
 ADS_INSTANCE="$ADS_INSTANCES/$ADS_INSTANCE_NAME"
 
-ADS_OUT="$ADS_INSTANCE/log/apacheds.out"
-ADS_PID="$ADS_INSTANCE/run/apacheds.pid"
-
 eval "java $JAVA_OPTS $ADS_CONTROLS $ADS_EXTENDED_OPERATIONS $ADS_INTERMEDIATE_RESPONSES -Dlog4j.configuration=file:/usr/local/apacheds/conf/log4j.properties -Dapacheds.log.dir=$ADS_INSTANCE/log -classpath $CLASSPATH org.apache.directory.server.UberjarMain $ADS_INSTANCE 2>&1 &"
 
 timeout 30 sh -c "while ! nc -z localhost 10389; do sleep 1; done"

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -5,10 +5,10 @@
 #
 # Environment Variable Prerequisites
 #
-#   Do not set the variables in this script. Instead put them into 
+#   Do not set the variables in this script. Instead put them into
 #   $ADS_HOME/bin/setenv.sh to keep your customizations separate.
 #
-#   ADS_HOME        (Optional) The directory that contains your apacheds 
+#   ADS_HOME        (Optional) The directory that contains your apacheds
 #                   install.  Defaults to the parent directory of the
 #                   directory containing this script.
 #
@@ -25,7 +25,7 @@
 #
 #   ADS_SHUTDOWN_PORT
 #                   (Optional) If specified, it must be a valid port number
-#                   between 1024 and 65536 on which ApacheDS will listen for 
+#                   between 1024 and 65536 on which ApacheDS will listen for
 #                   a connection to trigger a polite shutdown.  Defaults to 0
 #                   indicating a dynamic port allocation.
 #

--- a/run_apacheds.sh
+++ b/run_apacheds.sh
@@ -126,7 +126,8 @@ fi
 DN_COMP="$(echo "${DN}" | sed 's/,.*//')"
 export DN_COMP
 export RDN=${DN_COMP/=/: }
-export RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
+RDN_VAL="$(echo "${DN_COMP}" | sed 's/.*=//')"
+export RDN_VAL
 
 export CTX_ENTRY=`base64 -w 0 <<EOF
 dn: $DN


### PR DESCRIPTION
based on #11 and #12, includes changes from those branches, too.

- Fix lots of ShellCheck errors
- Disable some false-positive warnings
- remove unused variables ADS_OUT and ADS_PID